### PR TITLE
Support new mapping cli command list_scores to review scores

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -22,3 +22,8 @@ Make sure to run rebuild_mappings command before these commands (that have tag a
 1.  Help:  ./mapping_cli.py visualize -h
 1.  Another example:  ./mapping_cli.py visualize --visualizer AttackNavigator  --skip-validation
 1.  Another example:  ./mapping_cli.py visualize --visualizer AttackNavigator --tag "Azure Defender" --title "Azure Defender" --skip-validation
+
+New functionality to review scores values and comments
+1. ./mapping_cli.py list_scores --category Protect
+1. ./mapping_cli.py list_scores --category Protect --level Sub-technique
+1. ./mapping_cli.py list_scores --category Protect --level Technique --width 100

--- a/tools/db/model.py
+++ b/tools/db/model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, Table
+from sqlalchemy import Column, Integer, String, ForeignKey, Table, UniqueConstraint
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -9,6 +9,31 @@ mapping_tag_xref = Table('mapping_tag_xref', Base.metadata,
     Column('mapping_id', Integer, ForeignKey('mapping.mapping_id')),
     Column('tag_id', Integer, ForeignKey('tag.tag_id'))
 )
+
+
+class MappingTechniqueScore(Base):
+    __tablename__ = "mapping_technique_score"
+    id = Column(Integer, primary_key=True)
+    mapping_id = Column(Integer, ForeignKey('mapping.mapping_id'))
+    technique_id = Column(Integer, ForeignKey('technique.technique_id'))
+    score_id = Column(Integer, ForeignKey('score.score_id', ondelete='CASCADE'))
+
+    __table_args__ = (UniqueConstraint(mapping_id, technique_id, score_id),)
+    mapping = relationship("Mapping")
+    technique = relationship("Technique")
+    score = relationship("Score")
+
+class MappingSubTechniqueScore(Base):
+    __tablename__ = "mapping_sub_technique_score"
+    id = Column(Integer, primary_key=True)
+    mapping_id = Column(Integer, ForeignKey('mapping.mapping_id'), nullable=False)
+    sub_technique_id = Column(Integer, ForeignKey('sub_technique.technique_id'), nullable=False)
+    score_id = Column(Integer, ForeignKey('score.score_id'), nullable=False)
+
+    __table_args__ = (UniqueConstraint(mapping_id, sub_technique_id, score_id),)
+    mapping = relationship("Mapping")
+    sub_technique = relationship("SubTechnique")
+    score = relationship("Score")
 
 
 class Mapping(Base):
@@ -62,13 +87,11 @@ class SubTechnique(Base):
 
 
 class Score(Base):
-    __tablename__ = "mapping_score"
+    __tablename__ = "score"
     score_id = Column(Integer, primary_key=True)
-    mapping_id = Column("mapping_id", Integer, ForeignKey("mapping.mapping_id"))
-    sub_technique_id = Column("sub_technique_id", Integer, 
-        ForeignKey("sub_technique.sub_technique_id"))
-    score_function = Column(String, nullable=False)
+    category = Column(String, nullable=False)
     value = Column(String, nullable=False)
+    comments = Column(String, nullable=False)
 
 
 class Tag(Base):

--- a/tools/mapping_driver.py
+++ b/tools/mapping_driver.py
@@ -25,6 +25,10 @@ class MappingDriver():
         return self.mapping_db.query_mapping_files(tags, relationship)
     
 
+    def query_mapping_file_scores(self, categories, level):
+        return self.mapping_db.query_mapping_file_scores(categories, level)
+    
+
     def load_mapping_files_as_unit(self, map_files):
         paths = []
         for map_file in map_files:
@@ -68,9 +72,9 @@ class MappingDriver():
         return self.__validate_mapping_files(self.mapping_files)
 
 
-    def rebuild_mappings(self, skip_validation):
+    def rebuild_mappings(self, skip_validation, skip_attack):
         if skip_validation or self.validate_mapping_files():
-            self.mapping_db.init_database(self.mapping_files, self.mapping_validator.get_tags())
+            self.mapping_db.init_database(self.mapping_files, self.mapping_validator.get_tags(), skip_attack)
 
     
     def visualize(self, visualizer, output_dir, options={}):

--- a/tools/utils/utils.py
+++ b/tools/utils/utils.py
@@ -12,3 +12,7 @@ def file_path(path):
         return path
     else:
         raise NotAFileError(path)
+
+
+def chunkstring(string, length):
+    return (string[0+i:length+i] for i in range(0, len(string), length))


### PR DESCRIPTION
Support new mapping cli command list_scores to review scores by category.
Example, show all mappings with score Protect will display all
(sub-)techniques that have a Protect score along with their value and comments field.

FYI:  @clemskor @LeeKann create this command for the CLI to help us produce more consistent mappings.
