### PR TITLE
Fixed bugs related to supporting multiple platforms and ATT&CK versions.

### DIFF
--- a/tools/utils/attack_data_source.py
+++ b/tools/utils/attack_data_source.py
@@ -28,6 +28,9 @@ class AttackDataSource:
     def set_attack_version(self, version=None):
         version = version if version else self.latest_attack_version
 
+        if "." not in str(version):
+            version = f"{version}.0"
+
         if self.tc_src and self.current_version == version:
             return
 

--- a/tools/utils/mapping_validator.py
+++ b/tools/utils/mapping_validator.py
@@ -39,6 +39,8 @@ class MappingValidator:
             if valid_tags.exists():
                 with open(valid_tags) as file_object:
                     self.valid_tags[platform_dir.name] = file_object.read().splitlines()
+            else:
+                self.valid_tags[platform_dir.name] = []
 
 
     def verify_dates(self, mapping):


### PR DESCRIPTION
If a minor version of ATT&CK is not specified in a mapping file, default
it to minor version 0.  Account for platforms that haven't yet defined a
valid_tags file.