### PR TITLE
Add doc for visualizer config files.

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -52,6 +52,9 @@ optional arguments:
   --tags-file TAGS_FILE
                         Path to the file containing the list of valid tags
 ```
+
+The JSON schema used to validate the mapping files can be found in the [config/mapping_schema.json](config/mapping_schema.json) file.
+
 #### Examples
 -  Validate all mapping files in the default mappings directory (```../mappings```):</br>
   ```./mapping_cli.py validate```
@@ -100,6 +103,13 @@ optional arguments:
   --include-html        When generating a visualization, if supported,
                         generate an HTML version too.
 ```
+
+The set of configuration and template files used to generate the visualizations can be found in the config directory:
+- [config/markdown_summary.json](config/markdown_summary.json):  contains the introductory text for each platform that is displayed in the Introduction section of the Markdown Summary view for a platform.
+- [config/markdown_summary_template.html](config/markdown_summary_template.html):  contains the HTML template used when generating an HTML version of the Markdown Summary view.
+- [config/navigator_layer_config.yaml](config/navigator_layer_config.yaml):  contains configuration settings for the Navigator Layer visualizer such as the colors to utilize for each score category and whether to include numeric scores in the generated layer files.
+- [config/navigator_layer_template.json](config/navigator_layer_template.json):  contains the Navigator layer template used by the Navigator visualizer when generating Navigator layer files.
+
 #### Examples
 -  Generate [ATT&CK Navigator](https://mitre-attack.github.io/attack-navigator/) layers for each mapping file in the default mappings directory (```../mappings```):</br>
   ```./mapping_cli.py visualize --visualizer AttackNavigator```

--- a/tools/config/navigator_layer_config.yaml
+++ b/tools/config/navigator_layer_config.yaml
@@ -19,6 +19,7 @@ score_colors:
     Minimal:  "#bf6bff"
     Partial:  "#9305ff"
     Significant:  "#5c00a3"
+include_numeric_scores: False
 score_values:
     Minimal:  10
     Partial:  50

--- a/tools/visualizers/attack_navigator_visualizer.py
+++ b/tools/visualizers/attack_navigator_visualizer.py
@@ -100,10 +100,9 @@ class AttackNavigatorVisualizer(AbstractVisualizer):
         color = self.config["score_colors"][category][max_score]
         tech["color"] = color
 
-        # score_num is only necessary because we want to set score as a string (Minimal, Partial, Significant)
-        # but Navigator only supports numeric values :( For now, we just won't display a score at all.
         tech["score_num"] = self.config["score_values"][max_score]
-        #tech["score"] = self.config["score_values"][max_score]
+        if self.config["include_numeric_scores"]:
+            tech["score"] = self.config["score_values"][max_score]
 
         tech["score_display"] = max_score
         tech["category"] = category
@@ -125,7 +124,8 @@ class AttackNavigatorVisualizer(AbstractVisualizer):
             score_display = copy_src["score_display"]
             color = self.config["score_colors"][existing["category"]][score_display]
             existing["color"] = color
-            # existing["score"] = copy_src["score"]
+            if self.config["include_numeric_scores"]:
+                existing["score"] = copy_src["score"]
             existing["score_display"] = score_display
             existing["score_num"] = copy_src["score_num"]
         else:


### PR DESCRIPTION
Also enabled configuring whether the Navigator visualizer includes
numeric scores in the generated layer files.